### PR TITLE
compatible with bsd system

### DIFF
--- a/chcker_linux.go
+++ b/chcker_linux.go
@@ -1,0 +1,66 @@
+package tcp
+
+import (
+	"os"
+	"syscall"
+)
+
+// InitChecker creates inner epoll instance, call this before anything else
+func (s *Checker) InitChecker() error {
+	var err error
+	s.Lock()
+	defer s.Unlock()
+	// Check if we already initialized
+	if s.poolFd > 0 {
+		return nil
+	}
+	// Create epoll instance
+	s.poolFd, err = syscall.EpollCreate1(0)
+	if err != nil {
+		return os.NewSyscallError("epoll_create1", err)
+	}
+	return nil
+}
+
+// registerFd registers given fd to epoll with EPOLLOUT
+func (s *Checker) registerFd(fd int) error {
+	var event syscall.EpollEvent
+	event.Events = syscall.EPOLLOUT
+	event.Fd = int32(fd)
+	s.RLock()
+	defer s.RUnlock()
+	if err := syscall.EpollCtl(s.poolFd, syscall.EPOLL_CTL_ADD, fd, &event); err != nil {
+		return os.NewSyscallError("epoll_ctl", err)
+	}
+	return nil
+}
+
+// waitForConnected waits for epoll event of given fd with given timeout
+// The boolean returned indicates whether the previous connect is successful
+func (s *Checker) waitForConnected(fd int, timeoutMS int) (bool, error) {
+	var events [maxEpollEvents]syscall.EpollEvent
+	s.RLock()
+	epollFd := s.poolFd
+	if epollFd <= 0 {
+		return false, ErrNotInitialized
+	}
+	s.RUnlock()
+	nevents, err := syscall.EpollWait(epollFd, events[:], timeoutMS)
+	if err != nil {
+		return false, os.NewSyscallError("epoll_wait", err)
+	}
+
+	for ev := 0; ev < nevents; ev++ {
+		if int(events[ev].Fd) == fd {
+			errCode, err := syscall.GetsockoptInt(fd, syscall.SOL_SOCKET, syscall.SO_ERROR)
+			if err != nil {
+				return false, os.NewSyscallError("getsockopt", err)
+			}
+			if errCode != 0 {
+				return false, newErrConnect(errCode)
+			}
+			return true, nil
+		}
+	}
+	return false, nil
+}

--- a/checker_bsd.go
+++ b/checker_bsd.go
@@ -1,0 +1,81 @@
+// +build darwin dragonfly freebsd netbsd openbsd
+
+package tcp
+
+import (
+	"errors"
+	"os"
+	"syscall"
+)
+
+// InitChecker creates inner kqueue instance, call this before anything else
+func (s *Checker) InitChecker() error {
+	var err error
+	s.Lock()
+	defer s.Unlock()
+	// Check if we already initialized
+	if s.poolFd > 0 {
+		return nil
+	}
+	// Create kqueue instance
+	s.poolFd, err = syscall.Kqueue()
+	if err != nil {
+		return os.NewSyscallError("kqueue", err)
+	}
+	return nil
+}
+
+// registerFd registers give fd to kqueue with EVFILT_READ
+func (s *Checker) registerFd(fd int) error {
+	event := syscall.Kevent_t{
+		Ident:  uint64(fd),
+		Filter: syscall.EVFILT_WRITE,
+		Flags:  syscall.EV_ADD,
+	}
+	changes := []syscall.Kevent_t{event}
+	s.RLock()
+	defer s.RUnlock()
+	if _, err := syscall.Kevent(s.poolFd, changes, nil, nil); err != nil {
+		return os.NewSyscallError("kevent", err)
+	}
+	return nil
+}
+
+// waitForConnected waits for epoll event of given fd with given timeout
+// The boolean returned indicates whether the previous connect is successful
+func (s *Checker) waitForConnected(fd int, timeoutMS int) (bool, error) {
+	// events := make([]syscall.Kevent_t, 0, maxPoolEvents)
+	events := make([]syscall.Kevent_t, maxPoolEvents)
+	s.RLock()
+	if s.poolFd <= 0 {
+		return false, ErrNotInitialized
+	}
+	s.RUnlock()
+
+	timeoutNS := int64(timeoutMS * 1e6)
+	timeout := &syscall.Timespec{
+		Sec:  timeoutNS / 1e9,
+		Nsec: timeoutNS % 1e9,
+	}
+	n, err := syscall.Kevent(s.poolFd, nil, events, timeout)
+	if err != nil {
+		return false, os.NewSyscallError("kevent", err)
+	}
+	if n == 0 {
+		return false, os.NewSyscallError("kevent", errors.New("timeout"))
+	}
+
+	for i := 0; i < n; i++ {
+		if int(events[i].Ident) == fd {
+			errCode, err := syscall.GetsockoptInt(fd, syscall.SOL_SOCKET, syscall.SO_ERROR)
+			if err != nil {
+				return false, os.NewSyscallError("getsockopt", err)
+			}
+			if errCode != 0 {
+				return false, newErrConnect(errCode)
+			}
+			return true, nil
+		}
+	}
+	return false, nil
+}

--- a/socket.go
+++ b/socket.go
@@ -25,15 +25,6 @@ func createSocket() (int, error) {
 	return fd, err
 }
 
-// setSockOpts sets SOCK_NONBLOCK and TCP_QUICKACK for given fd
-func setSockOpts(fd int) error {
-	err := syscall.SetNonblock(fd, true)
-	if err != nil {
-		return err
-	}
-	return syscall.SetsockoptInt(fd, syscall.SOL_TCP, syscall.TCP_QUICKACK, 0)
-}
-
 var zeroLinger = syscall.Linger{Onoff: 1, Linger: 0}
 
 // setLinger sets SO_Linger with 0 timeout to given fd

--- a/socket_bsd.go
+++ b/socket_bsd.go
@@ -1,0 +1,14 @@
+// +build darwin dragonfly freebsd netbsd openbsd
+
+package tcp
+
+import "syscall"
+
+// setSockOpts sets SOCK_NONBLOCK for given fd
+func setSockOpts(fd int) error {
+	err := syscall.SetNonblock(fd, true)
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/socket_linux.go
+++ b/socket_linux.go
@@ -1,0 +1,12 @@
+package tcp
+
+import "syscall"
+
+// setSockOpts sets SOCK_NONBLOCK and TCP_QUICKACK for given fd
+func setSockOpts(fd int) error {
+	err := syscall.SetNonblock(fd, true)
+	if err != nil {
+		return err
+	}
+	return syscall.SetsockoptInt(fd, syscall.SOL_TCP, syscall.TCP_QUICKACK, 0)
+}


### PR DESCRIPTION
In freebsd system, `TCP_QUICKACK` socket option is not supported. There are no ways to control tcp protocol stack(maybe i miss something). 

If system support `quickack` feature, haproxy health check will send `RST` packet instead of `ACK` in tcp shake. 

In other systems like freebsd, health check will create real tcp connection. behavior is:
- `SYN`
- `SYN-ACK`
- `ACK`
- `RST`
