### PR TITLE
Add benchmark

### DIFF
--- a/pipe_pool.go
+++ b/pipe_pool.go
@@ -1,31 +1,6 @@
 package tcp
 
-import "sync"
-
-type pipePool struct {
-	pool sync.Pool
-}
-
-func newPipePool() pipePool {
-	return pipePool{sync.Pool{
-		New: func() interface{} {
-			return make(chan error, 1)
-		}},
-	}
-}
-
-func (p *pipePool) getPipe() chan error {
-	return p.pool.Get().(chan error)
-}
-
-func (p *pipePool) putBackPipe(pipe chan error) {
-	p.cleanPipe(pipe)
-	p.pool.Put(pipe)
-}
-
-func (p *pipePool) cleanPipe(pipe chan error) {
-	select {
-	case <-pipe:
-	default:
-	}
+type pipePool interface {
+	getPipe() chan error
+	putBackPipe(chan error)
 }

--- a/pipe_pool_dummy.go
+++ b/pipe_pool_dummy.go
@@ -1,0 +1,13 @@
+package tcp
+
+type pipePoolDummy struct{}
+
+func newPipePoolDummy() *pipePoolDummy {
+	return &pipePoolDummy{}
+}
+
+func (*pipePoolDummy) getPipe() chan error {
+	return make(chan error, 1)
+}
+
+func (*pipePoolDummy) putBackPipe(pipe chan error) {}

--- a/pipe_pool_linux_test.go
+++ b/pipe_pool_linux_test.go
@@ -1,0 +1,55 @@
+package tcp
+
+import "testing"
+
+func BenchmarkPipePoolDummyOK(b *testing.B) {
+	c, cancel := _newChecker(b)
+	defer cancel()
+	c.pipePool = newPipePoolDummy()
+
+	addr, stop := _startTestServer()
+	defer stop()
+	_benchmarkChecker(b, c, addr)
+}
+
+func BenchmarkPipePoolSyncPoolOK(b *testing.B) {
+	c, cancel := _newChecker(b)
+	defer cancel()
+	c.pipePool = newPipePoolSyncPool()
+
+	addr, stop := _startTestServer()
+	defer stop()
+	_benchmarkChecker(b, c, addr)
+}
+
+func BenchmarkPipePoolDummyErr(b *testing.B) {
+	c, cancel := _newChecker(b)
+	defer cancel()
+	c.pipePool = newPipePoolDummy()
+
+	_benchmarkChecker(b, c, AddrDead)
+}
+
+func BenchmarkPipePoolSyncPoolErr(b *testing.B) {
+	c, cancel := _newChecker(b)
+	defer cancel()
+	c.pipePool = newPipePoolSyncPool()
+
+	_benchmarkChecker(b, c, AddrDead)
+}
+
+func BenchmarkPipePoolDummyTimeout(b *testing.B) {
+	c, cancel := _newChecker(b)
+	defer cancel()
+	c.pipePool = newPipePoolDummy()
+
+	_benchmarkChecker(b, c, AddrTimeout)
+}
+
+func BenchmarkPipePoolSyncPoolTimeout(b *testing.B) {
+	c, cancel := _newChecker(b)
+	defer cancel()
+	c.pipePool = newPipePoolSyncPool()
+
+	_benchmarkChecker(b, c, AddrTimeout)
+}

--- a/pipe_pool_sync_pool.go
+++ b/pipe_pool_sync_pool.go
@@ -1,0 +1,31 @@
+package tcp
+
+import "sync"
+
+type pipePoolSyncPool struct {
+	pool sync.Pool
+}
+
+func newPipePoolSyncPool() *pipePoolSyncPool {
+	return &pipePoolSyncPool{sync.Pool{
+		New: func() interface{} {
+			return make(chan error, 1)
+		}},
+	}
+}
+
+func (p *pipePoolSyncPool) getPipe() chan error {
+	return p.pool.Get().(chan error)
+}
+
+func (p *pipePoolSyncPool) putBackPipe(pipe chan error) {
+	p.cleanPipe(pipe)
+	p.pool.Put(pipe)
+}
+
+func (p *pipePoolSyncPool) cleanPipe(pipe chan error) {
+	select {
+	case <-pipe:
+	default:
+	}
+}

--- a/result_pipes.go
+++ b/result_pipes.go
@@ -1,0 +1,7 @@
+package tcp
+
+type resultPipes interface {
+	popResultPipe(int) (chan error, bool)
+	deregisterResultPipe(int)
+	registerResultPipe(int, chan error)
+}

--- a/result_pipes_linux_test.go
+++ b/result_pipes_linux_test.go
@@ -1,0 +1,84 @@
+package tcp
+
+import (
+	"context"
+	"runtime"
+	"testing"
+	"time"
+)
+
+func _newChecker(b *testing.B) (*Checker, context.CancelFunc) {
+	c := NewChecker()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go c.CheckingLoop(ctx)
+
+	select {
+	case <-time.After(time.Second):
+		b.FailNow()
+	case <-c.WaitReady():
+	}
+	return c, cancel
+}
+
+func _benchmarkChecker(b *testing.B, c *Checker, addr string) {
+	b.SetParallelism(runtime.NumCPU() * 10)
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			c.CheckAddr(AddrDead, time.Second)
+		}
+	})
+	b.StopTimer()
+}
+
+func BenchmarkResultPipesMUOK(b *testing.B) {
+	c, cancel := _newChecker(b)
+	defer cancel()
+	c.resultPipes = newResultPipesMU()
+
+	addr, stop := _startTestServer()
+	defer stop()
+	_benchmarkChecker(b, c, addr)
+}
+
+func BenchmarkResultPipesSyncMapOK(b *testing.B) {
+	c, cancel := _newChecker(b)
+	defer cancel()
+	c.resultPipes = newResultPipesSyncMap()
+
+	addr, stop := _startTestServer()
+	defer stop()
+	_benchmarkChecker(b, c, addr)
+}
+func BenchmarkResultPipesMUErr(b *testing.B) {
+	c, cancel := _newChecker(b)
+	defer cancel()
+	c.resultPipes = newResultPipesMU()
+
+	_benchmarkChecker(b, c, AddrDead)
+}
+
+func BenchmarkResultPipesSyncMapErr(b *testing.B) {
+	c, cancel := _newChecker(b)
+	defer cancel()
+	c.resultPipes = newResultPipesSyncMap()
+
+	_benchmarkChecker(b, c, AddrDead)
+}
+
+func BenchmarkResultPipesMUTimeout(b *testing.B) {
+	c, cancel := _newChecker(b)
+	defer cancel()
+	c.resultPipes = newResultPipesMU()
+
+	_benchmarkChecker(b, c, AddrTimeout)
+}
+
+func BenchmarkResultPipesSyncMapTimeout(b *testing.B) {
+	c, cancel := _newChecker(b)
+	defer cancel()
+	c.resultPipes = newResultPipesSyncMap()
+
+	_benchmarkChecker(b, c, AddrTimeout)
+}

--- a/result_pipes_mu.go
+++ b/result_pipes_mu.go
@@ -1,0 +1,35 @@
+package tcp
+
+import "sync"
+
+type resultPipesMU struct {
+	l             sync.Mutex
+	fdResultPipes map[int]chan error
+}
+
+func newResultPipesMU() *resultPipesMU {
+	return &resultPipesMU{fdResultPipes: make(map[int]chan error)}
+}
+
+func (r *resultPipesMU) popResultPipe(fd int) (chan error, bool) {
+	r.l.Lock()
+	p, exists := r.fdResultPipes[fd]
+	if exists {
+		delete(r.fdResultPipes, fd)
+	}
+	r.l.Unlock()
+	return p, exists
+}
+
+func (r *resultPipesMU) deregisterResultPipe(fd int) {
+	r.l.Lock()
+	delete(r.fdResultPipes, fd)
+	r.l.Unlock()
+}
+
+func (r *resultPipesMU) registerResultPipe(fd int, pipe chan error) {
+	// NOTE: the pipe should have been put back if c.fdResultPipes[fd] exists.
+	r.l.Lock()
+	r.fdResultPipes[fd] = pipe
+	r.l.Unlock()
+}

--- a/result_pipes_sync_map.go
+++ b/result_pipes_sync_map.go
@@ -1,0 +1,31 @@
+package tcp
+
+import "sync"
+
+type resultPipesSyncMap struct {
+	sync.Map
+}
+
+func newResultPipesSyncMap() *resultPipesSyncMap {
+	return &resultPipesSyncMap{}
+}
+
+func (r *resultPipesSyncMap) popResultPipe(fd int) (chan error, bool) {
+	p, exist := r.Load(fd)
+	if exist {
+		r.Delete(fd)
+	}
+	if p != nil {
+		return p.(chan error), exist
+	}
+	return nil, exist
+}
+
+func (r *resultPipesSyncMap) deregisterResultPipe(fd int) {
+	r.Delete(fd)
+}
+
+func (r *resultPipesSyncMap) registerResultPipe(fd int, pipe chan error) {
+	// NOTE: the pipe should have been put back if c.fdResultPipes[fd] exists.
+	r.Store(fd, pipe)
+}


### PR DESCRIPTION
```
go version go1.11.4 linux/amd64

goos: linux
goarch: amd64
pkg: github.com/tevino/tcp-shaker
BenchmarkPipePoolDummyOK-32              	  300000	      4002 ns/op	     660 B/op	      16 allocs/op
BenchmarkPipePoolSyncPoolOK-32           	  300000	      3955 ns/op	     507 B/op	      14 allocs/op
BenchmarkPipePoolDummyErr-32             	  300000	      4026 ns/op	     613 B/op	      16 allocs/op
BenchmarkPipePoolSyncPoolErr-32          	  300000	      3973 ns/op	     526 B/op	      14 allocs/op
BenchmarkPipePoolDummyTimeout-32         	  300000	      3954 ns/op	     613 B/op	      16 allocs/op
BenchmarkPipePoolSyncPoolTimeout-32      	  300000	      3895 ns/op	     507 B/op	      14 allocs/op

BenchmarkResultPipesMUOK-32              	  300000	      4692 ns/op	     478 B/op	      12 allocs/op
BenchmarkResultPipesSyncMapOK-32         	  300000	      3902 ns/op	     506 B/op	      14 allocs/op
BenchmarkResultPipesMUErr-32             	  300000	      4399 ns/op	     478 B/op	      12 allocs/op
BenchmarkResultPipesSyncMapErr-32        	  300000	      3993 ns/op	     508 B/op	      14 allocs/op
BenchmarkResultPipesMUTimeout-32         	  300000	      4473 ns/op	     478 B/op	      12 allocs/op
BenchmarkResultPipesSyncMapTimeout-32    	  300000	      3947 ns/op	     507 B/op	      14 allocs/op
```