### PR TITLE
use x/sys/unix instead of syscall to fix EpollWait on Android

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,5 +7,6 @@ go:
   - "1.11.x"
 install:
   - go get "github.com/pkg/errors"
+  - go get "golang.org/x/sys/unix"
 script: go test -v -bench=. -benchmem ./...
 

--- a/README.md
+++ b/README.md
@@ -86,5 +86,6 @@ conn.Close()
 ## Special thanks to contributors
 
 - @lujjjh
+- @jakubgs Fixed compatibility on Android
 
 [tcp-handshake]: https://en.wikipedia.org/wiki/Handshaking#TCP_three-way_handshake

--- a/checker_linux.go
+++ b/checker_linux.go
@@ -4,10 +4,10 @@ import (
 	"context"
 	"sync"
 	"sync/atomic"
-	"syscall"
 	"time"
 
 	"github.com/pkg/errors"
+	"golang.org/x/sys/unix"
 )
 
 // Checker contains an epoll instance for TCP handshake checking
@@ -74,7 +74,7 @@ func (c *Checker) closePoller() error {
 	defer c.pollerLock.Unlock()
 	var err error
 	if c.pollerFD() > 0 {
-		err = syscall.Close(c.pollerFD())
+		err = unix.Close(c.pollerFD())
 	}
 	c.setPollerFD(-1)
 	return err
@@ -151,7 +151,7 @@ func (c *Checker) CheckAddrZeroLinger(addr string, timeout time.Duration, zeroLi
 		return err
 	}
 	// Socket should be closed anyway
-	defer syscall.Close(fd)
+	defer unix.Close(fd)
 
 	// Connect to the address
 	if success, cErr := connect(fd, rAddr); cErr != nil {

--- a/err.go
+++ b/err.go
@@ -2,7 +2,8 @@ package tcp
 
 import (
 	"errors"
-	"syscall"
+
+	"golang.org/x/sys/unix"
 )
 
 // ErrTimeout indicates I/O timeout
@@ -22,7 +23,7 @@ type ErrConnect struct {
 
 // newErrConnect returns a ErrConnect with given error code
 func newErrConnect(errCode int) *ErrConnect {
-	return &ErrConnect{syscall.Errno(errCode)}
+	return &ErrConnect{unix.Errno(errCode)}
 }
 
 // ErrCheckerAlreadyStarted indicates there is another instance of CheckingLoop running.

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/status-im/tcp-shaker
+module github.com/tevino/tcp-shaker
 
 go 1.13
 

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/status-im/tcp-shaker
+
+go 1.13
+
+require golang.org/x/sys v0.0.0-20191110163157-d32e6e3b99c4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+golang.org/x/sys v0.0.0-20191110163157-d32e6e3b99c4 h1:Hynbrlo6LbYI3H1IqXpkVDOcX/3HiPdhVEuyj5a59RM=
+golang.org/x/sys v0.0.0-20191110163157-d32e6e3b99c4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=


### PR DESCRIPTION
I encountered an issue [while working on something using `tcp-shaker`](https://github.com/status-im/status-react/issues/9394) which affects the `arm64` platform. Specifically the `EpollWait` call returns an `EpollEvent` with the file descriptor set to `0`.
This is the case for every flag configuration I've tried.

I've reported the issue in https://github.com/golang/go/issues/35479 but as the `syscall` package [has been frozen since Go 1.3](https://docs.google.com/document/d/1QXzI9I1pOfZPujQzxhyRy6EeHYTQitKKjHfpq0zpxZs) it most probably won't be fixed. But what I did find out is that the `x/sys/unix` package is an up-to-date drop-in replacement for the `syscall` package, and one that doesn't have this bug.

So here's a PR that replaces use of `syscall` with `x/sys/unix` to fix the Android issue.