### PR TITLE
Add IPV6 Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ _testmain.go
 *.exe
 *.test
 *.prof
+
+.idea

--- a/checker_linux.go
+++ b/checker_linux.go
@@ -145,8 +145,9 @@ func (c *Checker) CheckAddrZeroLinger(addr string, timeout time.Duration, zeroLi
 	if err != nil {
 		return err
 	}
+	_, ipv6 := rAddr.(*syscall.SockaddrInet6)
 	// Create socket with options set
-	fd, err := createSocketZeroLinger(zeroLinger)
+	fd, err := createSocketZeroLinger(zeroLinger, ipv6)
 	if err != nil {
 		return err
 	}

--- a/checker_linux.go
+++ b/checker_linux.go
@@ -145,9 +145,19 @@ func (c *Checker) CheckAddrZeroLinger(addr string, timeout time.Duration, zeroLi
 	if err != nil {
 		return err
 	}
-	_, ipv6 := rAddr.(*syscall.SockaddrInet6)
+
+	var domain int
+	switch rAddr.(type) {
+	case *unix.SockaddrInet4:
+		domain = unix.AF_INET
+	case *unix.SockaddrInet6:
+		domain = unix.AF_INET6
+	default:
+		return errors.New("Unrecognized IP address type")
+	}
+
 	// Create socket with options set
-	fd, err := createSocketZeroLinger(zeroLinger, ipv6)
+	fd, err := createSocketZeroLinger(zeroLinger, domain)
 	if err != nil {
 		return err
 	}

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,7 @@ module github.com/tevino/tcp-shaker
 
 go 1.13
 
-require golang.org/x/sys v0.0.0-20191110163157-d32e6e3b99c4
+require (
+	github.com/pkg/errors v0.9.1
+	golang.org/x/sys v0.0.0-20191110163157-d32e6e3b99c4
+)

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,4 @@
+github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
+github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 golang.org/x/sys v0.0.0-20191110163157-d32e6e3b99c4 h1:Hynbrlo6LbYI3H1IqXpkVDOcX/3HiPdhVEuyj5a59RM=
 golang.org/x/sys v0.0.0-20191110163157-d32e6e3b99c4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/socket.go
+++ b/socket.go
@@ -13,11 +13,22 @@ func parseSockAddr(addr string) (unix.Sockaddr, error) {
 	if err != nil {
 		return nil, err
 	}
-	var addr4 [4]byte
-	if tAddr.IP != nil {
-		copy(addr4[:], tAddr.IP.To4()) // copy last 4 bytes of slice to array
+	var addr4 [net.IPv4len]byte
+	if tAddr.IP == nil {
+		return &unix.SockaddrInet4{Port: tAddr.Port, Addr: addr4}, nil
 	}
-	return &unix.SockaddrInet4{Port: tAddr.Port, Addr: addr4}, nil
+	if v4 := tAddr.IP.To4(); v4 != nil {
+		if tAddr.IP != nil {
+			copy(addr4[:], tAddr.IP.To4()) // copy last 4 bytes of slice to array
+		}
+		return &unix.SockaddrInet4{Port: tAddr.Port, Addr: addr4}, nil
+	}
+
+	var addr6 [net.IPv6len]byte
+	if tAddr.IP != nil {
+		copy(addr6[:], tAddr.IP.To16()) // copy last 16 bytes of slice to array
+	}
+	return &unix.SockaddrInet6{Port: tAddr.Port, Addr: addr6}, nil
 }
 
 // connect calls the connect syscall with error handled.

--- a/socket_linux.go
+++ b/socket_linux.go
@@ -11,9 +11,9 @@ import (
 const maxEpollEvents = 32
 
 // createSocket creates a socket with necessary options set.
-func createSocketZeroLinger(zeroLinger bool, ipv6 bool) (fd int, err error) {
+func createSocketZeroLinger(zeroLinger bool, domain int) (fd int, err error) {
 	// Create socket
-	fd, err = _createNonBlockingSocket(ipv6)
+	fd, err = _createNonBlockingSocket(domain)
 	if err == nil {
 		if zeroLinger {
 			err = _setZeroLinger(fd)
@@ -23,9 +23,9 @@ func createSocketZeroLinger(zeroLinger bool, ipv6 bool) (fd int, err error) {
 }
 
 // createNonBlockingSocket creates a non-blocking socket with necessary options all set.
-func _createNonBlockingSocket(ipv6 bool) (int, error) {
+func _createNonBlockingSocket(domain int) (int, error) {
 	// Create socket
-	fd, err := _createSocket(ipv6)
+	fd, err := _createSocket(domain)
 	if err != nil {
 		return 0, err
 	}
@@ -38,11 +38,7 @@ func _createNonBlockingSocket(ipv6 bool) (int, error) {
 }
 
 // createSocket creates a socket with CloseOnExec set
-func _createSocket(ipv6 bool) (int, error) {
-	domain := unix.AF_INET
-	if ipv6 {
-		domain = unix.AF_INET6
-	}
+func _createSocket(domain int) (int, error) {
 	fd, err := unix.Socket(domain, unix.SOCK_STREAM, 0)
 	unix.CloseOnExec(fd)
 	return fd, err

--- a/socket_linux.go
+++ b/socket_linux.go
@@ -11,9 +11,9 @@ import (
 const maxEpollEvents = 32
 
 // createSocket creates a socket with necessary options set.
-func createSocketZeroLinger(zeroLinger bool) (fd int, err error) {
+func createSocketZeroLinger(zeroLinger bool, ipv6 bool) (fd int, err error) {
 	// Create socket
-	fd, err = _createNonBlockingSocket()
+	fd, err = _createNonBlockingSocket(ipv6)
 	if err == nil {
 		if zeroLinger {
 			err = _setZeroLinger(fd)
@@ -23,9 +23,9 @@ func createSocketZeroLinger(zeroLinger bool) (fd int, err error) {
 }
 
 // createNonBlockingSocket creates a non-blocking socket with necessary options all set.
-func _createNonBlockingSocket() (int, error) {
+func _createNonBlockingSocket(ipv6 bool) (int, error) {
 	// Create socket
-	fd, err := _createSocket()
+	fd, err := _createSocket(ipv6)
 	if err != nil {
 		return 0, err
 	}
@@ -38,8 +38,12 @@ func _createNonBlockingSocket() (int, error) {
 }
 
 // createSocket creates a socket with CloseOnExec set
-func _createSocket() (int, error) {
-	fd, err := unix.Socket(unix.AF_INET, unix.SOCK_STREAM, 0)
+func _createSocket(ipv6 bool) (int, error) {
+	domain := unix.AF_INET
+	if ipv6 {
+		domain = unix.AF_INET6
+	}
+	fd, err := unix.Socket(domain, unix.SOCK_STREAM, 0)
 	unix.CloseOnExec(fd)
 	return fd, err
 }


### PR DESCRIPTION
Using a similar approach as previously in #17 but passing down the socket type
(either `AF_INET` or `AF_INET6` rather than a bool). Includes tests for live and 
dead addresses.

Closes: #17 

Note: I'm keeping the commits separated for now to make the history clear,
but I'll squash prior to merge if approved.