### PR TITLE
Introduce DefaultChecker for a shared instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,21 +59,15 @@ The reason for a fake implementation is that there is currently no way to perfor
 ## Usage
 
 ```go
-import "github.com/tevino/tcp-shaker"
+import (
+	tcpshaker "github.com/tevino/tcp-shaker"
+)
 
 // Initializing the checker
 // It is expected to be shared among goroutines, only one instance is necessary.
-c := NewChecker()
-
-ctx, stopChecker := context.WithCancel(context.Background())
-defer stopChecker()
-go func() {
-	if err := c.CheckingLoop(ctx); err != nil {
-		fmt.Println("checking loop stopped due to fatal error: ", err)
-	}
-}()
-
-<-c.WaitReady()
+// The DefaultChecker is a shared singleton, ready to use.
+// It automatically handles its own lifecycle in the background.
+c := tcpshaker.DefaultChecker()
 
 // Checking google.com
 

--- a/README.md
+++ b/README.md
@@ -58,29 +58,49 @@ The reason for a fake implementation is that there is currently no way to perfor
 
 ## Usage
 
+### Quick start (recommended)
+
 ```go
 import (
 	tcpshaker "github.com/tevino/tcp-shaker"
 )
 
-// Initializing the checker
-// It is expected to be shared among goroutines, only one instance is necessary.
-// The DefaultChecker is a shared singleton, ready to use.
-// It automatically handles its own lifecycle in the background.
-c := tcpshaker.DefaultChecker()
+// Get the global singleton Checker instance
+checker := tcpshaker.DefaultChecker()
+
 
 // Checking google.com
-
-timeout := time.Second * 1
-err := c.CheckAddr("google.com:80", timeout)
+err := checker.CheckAddr("google.com:80", time.Second)
 switch err {
 case ErrTimeout:
-	fmt.Println("Connect to Google timed out")
+	fmt.Println("Connect to Google timed out after 1s")
 case nil:
 	fmt.Println("Connect to Google succeeded")
 default:
 	fmt.Println("Error occurred while connecting: ", err)
 }
+```
+
+### Manual initialization
+
+For fine-grained control of the lifecycle of the `Checker`.
+
+```
+// Initializing the checker
+// Only a single instance is needed and it's safe to use among goroutines.
+checker := NewChecker()
+
+ctx, stopChecker := context.WithCancel(context.Background())
+defer stopChecker()
+go func() {
+	if err := checker.CheckingLoop(ctx); err != nil {
+		fmt.Println("checking loop stopped due to fatal error: ", err)
+	}
+}()
+
+<-checker.WaitReady()
+
+// now the checker could be used as shown in the previous example.
 ```
 
 ## TODO
@@ -92,5 +112,6 @@ default:
 - @lujjjh Added zero linger support for non-Linux platform
 - @jakubgs Fixed compatibility on Android
 - @kirk91 Added support for IPv6
+- @eos175 Added a global singleton for `Checker`
 
 [tcp-handshake]: https://en.wikipedia.org/wiki/Handshaking#TCP_three-way_handshake

--- a/default_checker.go
+++ b/default_checker.go
@@ -1,0 +1,42 @@
+package tcp
+
+import (
+	"context"
+	"log"
+	"os/signal"
+	"sync"
+	"syscall"
+)
+
+var (
+	defaultChecker *Checker
+	once           sync.Once
+)
+
+// DefaultChecker returns a shared singleton instance of the Checker.
+//
+// It starts the Checker's CheckingLoop in a goroutine with a context that
+// listens for system signals (SIGINT, SIGTERM) to stop gracefully. This function
+// blocks until the Checker is ready for use.
+func DefaultChecker() *Checker {
+	once.Do(func() {
+		defaultChecker = NewChecker()
+
+		go func() {
+			ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+			defer stop()
+
+			// If the checking loop stops with an error, we log it.
+			// We use the standard log package to avoid external dependencies.
+			if err := defaultChecker.CheckingLoop(ctx); err != nil {
+				log.Printf("tcpshaker: TCP checking loop stopped with an error: %v", err)
+			}
+		}()
+
+		// Wait for the checker to be ready to ensure initialization is complete
+		// before returning the instance.
+		<-defaultChecker.WaitReady()
+	})
+
+	return defaultChecker
+}


### PR DESCRIPTION
Introduces a DefaultChecker singleton to provide a simple and efficient
way to use a shared Checker instance across an application.

#28 

This change solves the need for users to manually manage the lifecycle
of a Checker. By providing a default, shared instance, it simplifies
the API and ensures resources are used efficiently.

The DefaultChecker:
- Is initialized only once using `sync.Once`.
- Runs its own `CheckingLoop` in a background goroutine.
- Handles graceful shutdown on SIGINT and SIGTERM signals.
- Logs errors using the standard `log` package to avoid new dependencies.

The README usage example is also updated to reflect this new, simpler API.